### PR TITLE
Fix memory leak when array parsing fails

### DIFF
--- a/leptjson.c
+++ b/leptjson.c
@@ -213,8 +213,10 @@ static int lept_parse_array(lept_context* c, lept_value* v) {
     for (;;) {
         lept_value e;
         lept_init(&e);
-        if ((ret = lept_parse_value(c, &e)) != LEPT_PARSE_OK)
+        if ((ret = lept_parse_value(c, &e)) != LEPT_PARSE_OK) {
+            lept_free(&e);
             break;
+        }
         memcpy(lept_context_push(c, sizeof(lept_value)), &e, sizeof(lept_value));
         size++;
         lept_parse_whitespace(c);


### PR DESCRIPTION
## Summary
- free partially parsed array elements on parse error

## Testing
- `gcc -o test test.c leptjson.c -std=c89 -pedantic -Wall -Wextra -lm -O2`
- `./test`

------
https://chatgpt.com/codex/tasks/task_e_6865b4e02f288322999b59d547244690