### PR TITLE
Fix memory leak on root-not-singular parse error

### DIFF
--- a/leptjson.c
+++ b/leptjson.c
@@ -339,6 +339,7 @@ int lept_parse(lept_value* v, const char* json) {
     if ((ret = lept_parse_value(&c, v)) == LEPT_PARSE_OK) {
         lept_parse_whitespace(&c);
         if (*c.json != '\0') {
+            lept_free(v);
             v->type = LEPT_NULL;
             ret = LEPT_PARSE_ROOT_NOT_SINGULAR;
         }


### PR DESCRIPTION
## Summary
- free parsed value when extra characters follow a JSON value

## Testing
- `gcc -std=c89 -Wall -Wextra -pedantic -fsanitize=address -fsanitize=leak -g test.c leptjson.c -o test && ./test > /tmp/test.log`
- `LSAN_OPTIONS=exitcode=23 ./test`

------
https://chatgpt.com/codex/tasks/task_e_6865b974ff388322a4cd0caeefc2b16c